### PR TITLE
set content to panel Node instead of panel.innerHTML

### DIFF
--- a/src/tablist/TabList.js
+++ b/src/tablist/TabList.js
@@ -630,7 +630,7 @@ var tabbifyOne = function (el) {
     tabs.push({
       'title': panel.getAttribute('data-title') ||
           panel.querySelector('header').innerHTML,
-      'content': panel.innerHTML,
+      'content': panel,
       'selected': panel.getAttribute('data-selected') === 'true'
     });
   }


### PR DESCRIPTION
Currently, TabList sets the active tab's content to the panel's innerHTML, but this can cause issues. The issue I ran into is that I am attaching eventListeners to content inside the panel, and these are not preserved when using innerHTML.

https://github.com/usgs/hazdev-tablist/issues/20
